### PR TITLE
Add read operation support for filter definition

### DIFF
--- a/MongoDbGenericRepository/Abstractions/IBaseReadOnlyRepository.cs
+++ b/MongoDbGenericRepository/Abstractions/IBaseReadOnlyRepository.cs
@@ -50,6 +50,30 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>;
 
         /// <summary>
+        /// Asynchronously returns one document given filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TDocument> GetOneAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null,
+            string partitionKey = null, CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>;
+
+        /// <summary>
+        /// Returns one document given filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        TDocument GetOne<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>;
+
+        /// <summary>
         /// Asynchronously returns one document given an expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -83,6 +107,29 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>;
 
+        /// <summary>
+        /// Returns true if any of the document of the collection matches the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<bool> AnyAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>;
+
+        /// <summary>
+        /// Returns true if any of the document of the collection matches the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        bool Any<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>;
 
         /// <summary>
         /// Returns true if any of the document of the collection matches the filter condition.
@@ -112,6 +159,30 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<List<TDocument>> GetAllAsync<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            FindOptions findOption = null, string partitionKey = null, CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>;
+
+        /// <summary>
+        /// Returns a list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        List<TDocument> GetAll<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>;
+        
+        /// <summary>
+        /// Asynchronously returns a list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         /// <param name="cancellationToken">An optional cancellation Token.</param>
@@ -130,6 +201,31 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>;
 
+        /// <summary>
+        /// Asynchronously counts how many documents match the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partitionKey</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<long> CountAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null,
+            string partitionKey = null, CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>;
+
+        /// <summary>
+        /// Counts how many documents match the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partitionKey</param>
+        long Count<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null,
+            string partitionKey = null)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>;
+        
         /// <summary>
         /// Asynchronously counts how many documents match the filter condition.
         /// </summary>

--- a/MongoDbGenericRepository/Abstractions/IReadOnlyMongoRepository.TKey.cs
+++ b/MongoDbGenericRepository/Abstractions/IReadOnlyMongoRepository.TKey.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Driver;
 using MongoDbGenericRepository.Models;

--- a/MongoDbGenericRepository/DataAccess/Read/MongoDbReader.Main.cs
+++ b/MongoDbGenericRepository/DataAccess/Read/MongoDbReader.Main.cs
@@ -58,6 +58,39 @@ namespace MongoDbGenericRepository.DataAccess.Read
         }
 
         /// <summary>
+        /// Asynchronously returns one document given filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TDocument> GetOneAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption).FirstOrDefaultAsync(cancellationToken); 
+        }
+
+        /// <summary>
+        /// Returns one document given filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual TDocument GetOne<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption).FirstOrDefault(); 
+        }
+
+        /// <summary>
         /// Asynchronously returns one document given an expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -105,6 +138,41 @@ namespace MongoDbGenericRepository.DataAccess.Read
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual async Task<bool> AnyAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            var count = await HandlePartitioned<TDocument, TKey>(partitionKey).CountDocumentsAsync(condition, countOption, cancellationToken);
+            return count > 0;
+        }
+
+        /// <summary>
+        /// Returns true if any of the document of the collection matches the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual bool Any<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null,
+            string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            var count = HandlePartitioned<TDocument, TKey>(partitionKey).CountDocuments(condition, countOption);
+            return count > 0;
+        }
+
+        /// <summary>
+        /// Returns true if any of the document of the collection matches the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         /// <param name="cancellationToken">An optional cancellation Token.</param>
@@ -136,6 +204,39 @@ namespace MongoDbGenericRepository.DataAccess.Read
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<List<TDocument>> GetAllAsync<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            FindOptions findOption = null, string partitionKey = null, CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption).ToListAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns a list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual List<TDocument> GetAll<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null,
+            string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption).ToList();
+        }
+
+        /// <summary>
+        /// Asynchronously returns a list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         /// <param name="cancellationToken">An optional cancellation Token.</param>
@@ -158,6 +259,39 @@ namespace MongoDbGenericRepository.DataAccess.Read
             where TKey : IEquatable<TKey>
         {
             return HandlePartitioned<TDocument, TKey>(partitionKey).Find(filter).ToList();
+        }
+
+        /// <summary>
+        /// Asynchronously counts how many documents match the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partitionKey</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<long> CountAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null,
+            string partitionKey = null, CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).CountDocumentsAsync(condition, countOption, cancellationToken);
+        }
+
+        /// <summary>
+        /// Counts how many documents match the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partitionKey</param>
+        public virtual long Count<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null,
+            string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).CountDocuments(condition, countOption);
         }
 
         /// <summary>

--- a/MongoDbGenericRepository/KeyTypedRepository/BaseMongoRepository.TKey.ReadOnly.cs
+++ b/MongoDbGenericRepository/KeyTypedRepository/BaseMongoRepository.TKey.ReadOnly.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MongoDbGenericRepository

--- a/MongoDbGenericRepository/ReadOnlyMongoRepository.cs
+++ b/MongoDbGenericRepository/ReadOnlyMongoRepository.cs
@@ -71,6 +71,35 @@ namespace MongoDbGenericRepository
         {
             return MongoDbReader.GetById<TDocument, TKey>(id, partitionKey);
         }
+        
+        /// <summary>
+        /// Asynchronously returns one document given filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public Task<TDocument> GetOneAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetOneAsync<TDocument, TKey>(condition, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns one document given filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public TDocument GetOne<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null,
+            string partitionKey = null) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetOne<TDocument, TKey>(condition, findOption, partitionKey);
+        }
 
         /// <summary>
         /// Asynchronously returns one document given an expression filter.
@@ -114,6 +143,34 @@ namespace MongoDbGenericRepository
         {
             return MongoDbReader.GetCursor<TDocument, TKey>(filter, partitionKey);
         }
+        
+        /// <summary>
+        /// Returns true if any of the document of the collection matches the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public Task<bool> AnyAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.AnyAsync<TDocument, TKey>(condition, countOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns true if any of the document of the collection matches the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public bool Any<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null, string partitionKey = null) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.Any<TDocument, TKey>(condition, countOption, partitionKey);
+        }
 
         /// <summary>
         /// Returns true if any of the document of the collection matches the filter condition.
@@ -143,6 +200,35 @@ namespace MongoDbGenericRepository
         {
             return MongoDbReader.Any<TDocument, TKey>(filter, partitionKey);
         }
+        
+        /// <summary>
+        /// Asynchronously returns a list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public Task<List<TDocument>> GetAllAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetAllAsync<TDocument, TKey>(condition, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns a list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public List<TDocument> GetAll<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null,
+            string partitionKey = null) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetAll<TDocument, TKey>(condition, findOption, partitionKey);
+        }
 
         /// <summary>
         /// Asynchronously returns a list of the documents matching the filter condition.
@@ -171,6 +257,35 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>
         {
             return MongoDbReader.GetAll<TDocument, TKey>(filter, partitionKey);
+        }
+        
+        /// <summary>
+        /// Asynchronously counts how many documents match the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partitionKey</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public Task<long> CountAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.CountAsync<TDocument, TKey>(condition, countOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Counts how many documents match the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="countOption">A mongodb counting option.</param>
+        /// <param name="partitionKey">An optional partitionKey</param>
+        public long Count<TDocument, TKey>(FilterDefinition<TDocument> condition, CountOptions countOption = null,
+            string partitionKey = null) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.Count<TDocument, TKey>(condition, countOption, partitionKey);
         }
 
         /// <summary>


### PR DESCRIPTION
### Overview

This PR add some read operation using native FilterDefinition of MongoDriver for C#.

### Do we need that ?

As far as I enjoy this package for a while, things became a bit more complex when it comes to make use of some advance filter options support from mongodb (like collation, strength, batch size, disk using,..) that I usually do by inherit to make my own repository with some extra operation methods.

But I found that pretty cumbersome working with multiple project, I do have to copy and paste those code all over around. So, how about support them right on the root package ?

Sound good for me, but I don't know if that considerable adding to the root package. I was intended to add all CRUD operations but this PR just add some read operations (let me know if I should implement the rest CRUD operations).

### Testing

Due to the current testing implement install nuget package, I made another branch to implement the test over some newly added operation. If this PR was merge, I'll make another PR for those later. The branch was [here](https://github.com/khanhna/mongodb-generic-repository/tree/feature/read_process_added_with_test)