### PR TITLE
Add some native crud using native mongo db operation

### DIFF
--- a/MongoDbGenericRepository/Abstractions/IBaseMongoRepository.cs
+++ b/MongoDbGenericRepository/Abstractions/IBaseMongoRepository.cs
@@ -21,6 +21,18 @@ namespace MongoDbGenericRepository
         /// Asynchronously returns a paginated list of the documents matching the filter condition.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="skipNumber">The number of documents you want to skip. Default value is 0.</param>
+        /// <param name="takeNumber">The number of documents you want to take. Default value is 50.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        Task<List<TDocument>> GetPaginatedAsync<TDocument>(FilterDefinition<TDocument> condition, FindOptions findOption = null, int skipNumber = 0, int takeNumber = 50, string partitionKey = null)
+            where TDocument : IDocument;
+        
+        /// <summary>
+        /// Asynchronously returns a paginated list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <param name="filter"></param>
         /// <param name="skipNumber">The number of documents you want to skip. Default value is 0.</param>
         /// <param name="takeNumber">The number of documents you want to take. Default value is 50.</param>
@@ -28,6 +40,20 @@ namespace MongoDbGenericRepository
         Task<List<TDocument>> GetPaginatedAsync<TDocument>(Expression<Func<TDocument, bool>> filter, int skipNumber = 0, int takeNumber = 50, string partitionKey = null)
             where TDocument : IDocument;
 
+        /// <summary>
+        /// Asynchronously returns a paginated list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="skipNumber">The number of documents you want to skip. Default value is 0.</param>
+        /// <param name="takeNumber">The number of documents you want to take. Default value is 50.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        Task<List<TDocument>> GetPaginatedAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null, int skipNumber = 0, int takeNumber = 50, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
         /// <summary>
         /// Asynchronously returns a paginated list of the documents matching the filter condition.
         /// </summary>

--- a/MongoDbGenericRepository/Abstractions/IBaseReadOnlyRepository.cs
+++ b/MongoDbGenericRepository/Abstractions/IBaseReadOnlyRepository.cs
@@ -101,6 +101,18 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        IFindFluent<TDocument, TDocument> GetCursor<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
+        /// <summary>
+        /// Returns a collection cursor.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         IFindFluent<TDocument, TDocument> GetCursor<TDocument, TKey>(Expression<Func<TDocument, bool>> filter, string partitionKey = null)
@@ -258,6 +270,24 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TDocument> GetByMaxAsync<TDocument, TKey>(
+            FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> maxValueSelector,
+            FindOptions findOption = null,
+            string partitionKey = null, CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
+        /// <summary>
+        /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="maxValueSelector">A property selector to order by descending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -274,6 +304,19 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="orderByDescending">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        TDocument GetByMax<TDocument, TKey>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, object>> orderByDescending, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
+        /// <summary>
+        /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="orderByDescending">A property selector to order by descending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -281,6 +324,24 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>;
 
+        /// <summary>
+        /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector for the minimum value you are looking for.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TDocument> GetByMinAsync<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> minValueSelector,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
         /// <summary>
         /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
         /// </summary>
@@ -302,6 +363,19 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector for the minimum value you are looking for.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        TDocument GetByMin<TDocument, TKey>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, object>> minValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
+        /// <summary>
+        /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="minValueSelector">A property selector for the minimum value you are looking for.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -309,6 +383,26 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>;
 
+        /// <summary>
+        /// Gets the maximum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector for the maximum value you are looking for.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TValue> GetMaxValueAsync<TDocument, TKey, TValue>(
+            FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> maxValueSelector,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
         /// <summary>
         /// Gets the maximum value of a property in a mongodb collections that is satisfying the filter.
         /// </summary>
@@ -333,6 +427,20 @@ namespace MongoDbGenericRepository
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        TValue GetMaxValue<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, TValue>> maxValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
+        /// <summary>
+        /// Gets the maximum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="maxValueSelector">A property selector to order by ascending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -340,6 +448,26 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>;
 
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TValue> GetMinValueAsync<TDocument, TKey, TValue>(
+            FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> minValueSelector,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
         /// <summary>
         /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
         /// </summary>
@@ -358,6 +486,20 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>;
 
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        TValue GetMinValue<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, TValue>> minValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
         /// <summary>
         /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
         /// </summary>
@@ -443,6 +585,48 @@ namespace MongoDbGenericRepository
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A projection definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TProjection> ProjectOneAsync<TDocument, TProjection, TKey>(
+            FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class;
+        
+        /// <summary>
+        /// Asynchronously returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TProjection> ProjectOneAsync<TDocument, TProjection, TKey>(
+            FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class;
+        
+        /// <summary>
+        /// Asynchronously returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="projection">The projection expression.</param>
         /// <param name="partitionKey">An optional partition key.</param>
@@ -456,6 +640,36 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>
             where TProjection : class;
 
+        /// <summary>
+        /// Returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A projection definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        TProjection ProjectOne<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition, ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class;
+        
+        /// <summary>
+        /// Returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        TProjection ProjectOne<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class;
+        
         /// <summary>
         /// Returns a projected document matching the filter condition.
         /// </summary>
@@ -476,6 +690,48 @@ namespace MongoDbGenericRepository
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A projection definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection, TKey>(
+            FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class;
+        
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection, TKey>(
+            FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class;
+        
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="projection">The projection expression.</param>
         /// <param name="partitionKey">An optional partition key.</param>
@@ -489,6 +745,36 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>
             where TProjection : class;
 
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A projection definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        List<TProjection> ProjectMany<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition, ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class;
+        
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        List<TProjection> ProjectMany<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class;
+        
         /// <summary>
         /// Asynchronously returns a list of projected documents matching the filter condition.
         /// </summary>
@@ -556,6 +842,29 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="sortSelector">The property selector.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="ascending">Order of the sorting.</param>
+        /// <param name="skipNumber">The number of documents you want to skip. Default value is 0.</param>
+        /// <param name="takeNumber">The number of documents you want to take. Default value is 50.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        Task<List<TDocument>> GetSortedPaginatedAsync<TDocument, TKey>(
+            FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> sortSelector,
+            FindOptions findOption = null,
+            bool ascending = true,
+            int skipNumber = 0,
+            int takeNumber = 50,
+            string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
+        /// <summary>
+        /// Asynchronously returns a paginated list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="sortSelector">The property selector.</param>
         /// <param name="ascending">Order of the sorting.</param>
@@ -572,6 +881,29 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>;
 
+        /// <summary>
+        /// Asynchronously returns a paginated list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="sortDefinition">The sort definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="skipNumber">The number of documents you want to skip. Default value is 0.</param>
+        /// <param name="takeNumber">The number of documents you want to take. Default value is 50.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<List<TDocument>> GetSortedPaginatedAsync<TDocument, TKey>(
+            FilterDefinition<TDocument> condition,
+            SortDefinition<TDocument> sortDefinition,
+            FindOptions findOption = null,
+            int skipNumber = 0,
+            int takeNumber = 50,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
         /// <summary>
         /// Asynchronously returns a paginated list of the documents matching the filter condition.
         /// </summary>

--- a/MongoDbGenericRepository/Abstractions/IReadOnlyMongoRepository.TKey.cs
+++ b/MongoDbGenericRepository/Abstractions/IReadOnlyMongoRepository.TKey.cs
@@ -49,6 +49,15 @@ namespace MongoDbGenericRepository
         /// Returns a collection cursor.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        IFindFluent<TDocument, TDocument> GetCursor<TDocument>(FilterDefinition<TDocument> condition, FindOptions findOption = null, string partitionKey = null) where TDocument : IDocument<TKey>;
+        
+        /// <summary>
+        /// Returns a collection cursor.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         IFindFluent<TDocument, TDocument> GetCursor<TDocument>(Expression<Func<TDocument, bool>> filter, string partitionKey = null) where TDocument : IDocument<TKey>;
@@ -109,12 +118,38 @@ namespace MongoDbGenericRepository
         /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TDocument> GetByMaxAsync<TDocument>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> maxValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>;
+        
+        /// <summary>
+        /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="orderByDescending">A property selector to order by descending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
         Task<TDocument> GetByMaxAsync<TDocument>(Expression<Func<TDocument, bool>> filter, Expression<Func<TDocument, object>> orderByDescending, string partitionKey = null)
             where TDocument : IDocument<TKey>;
 
+        /// <summary>
+        /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        TDocument GetByMax<TDocument>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, object>> maxValueSelector,
+            FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>;
+        
         /// <summary>
         /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
         /// </summary>
@@ -127,6 +162,20 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>;
 
         /// <summary>
+        /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TDocument> GetByMinAsync<TDocument>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> minValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>;
+        
+        /// <summary>
         /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
@@ -137,6 +186,18 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>;
 
         /// <summary>
+        /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        TDocument GetByMin<TDocument>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> minValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>;
+        
+        /// <summary>
         /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
@@ -144,6 +205,21 @@ namespace MongoDbGenericRepository
         /// <param name="orderByAscending">A property selector to order by ascending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
         TDocument GetByMin<TDocument>(Expression<Func<TDocument, bool>> filter, Expression<Func<TDocument, object>> orderByAscending, string partitionKey = null)
+            where TDocument : IDocument<TKey>;
+
+        /// <summary>
+        /// Gets the maximum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TValue">The type of the field for which you want the maximum value.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TValue> GetMaxValueAsync<TDocument, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> maxValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default)
             where TDocument : IDocument<TKey>;
 
         /// <summary>
@@ -162,6 +238,19 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        TValue GetMaxValue<TDocument, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> maxValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>;
+
+        /// <summary>
+        /// Gets the maximum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="maxValueSelector">A property selector to order by ascending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -173,10 +262,38 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TValue> GetMinValueAsync<TDocument, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> minValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>;
+
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="minValueSelector">A property selector to order by ascending.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         Task<TValue> GetMinValueAsync<TDocument, TValue>(Expression<Func<TDocument, bool>> filter, Expression<Func<TDocument, TValue>> minValueSelector, string partitionKey = null)
+            where TDocument : IDocument<TKey>;
+
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        TValue GetMinValue<TDocument, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> minValueSelector, FindOptions findOption = null, string partitionKey = null)
             where TDocument : IDocument<TKey>;
 
         /// <summary>
@@ -250,12 +367,78 @@ namespace MongoDbGenericRepository
         /// Asynchronously returns a projected document matching the filter condition.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TProjection> ProjectOneAsync<TDocument, TProjection>(
+            FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TProjection : class;
+
+        /// <summary>
+        /// Asynchronously returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<TProjection> ProjectOneAsync<TDocument, TProjection>(
+            FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TProjection : class;
+        
+        /// <summary>
+        /// Asynchronously returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="projection">The projection expression.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         Task<TProjection> ProjectOneAsync<TDocument, TProjection>(Expression<Func<TDocument, bool>> filter, Expression<Func<TDocument, TProjection>> projection, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TProjection : class;
+
+        /// <summary>
+        /// Returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        TProjection ProjectOne<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TProjection : class;
+
+        /// <summary>
+        /// Returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        TProjection ProjectOne<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null)
             where TDocument : IDocument<TKey>
             where TProjection : class;
 
@@ -276,10 +459,76 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection>(
+            FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TProjection : class;
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection>(
+            FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TProjection : class;
+        
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="projection">The projection expression.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection>(Expression<Func<TDocument, bool>> filter, Expression<Func<TDocument, TProjection>> projection, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TProjection : class;
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        List<TProjection> ProjectMany<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TProjection : class;
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        List<TProjection> ProjectMany<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null)
             where TDocument : IDocument<TKey>
             where TProjection : class;
 

--- a/MongoDbGenericRepository/BaseMongoRepository.Delete.cs
+++ b/MongoDbGenericRepository/BaseMongoRepository.Delete.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using MongoDB.Driver;
 
 namespace MongoDbGenericRepository
 {
@@ -32,6 +33,19 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>;
 
         /// <summary>
+        /// Deletes a document matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        long DeleteOne<TDocument, TKey>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
+        /// <summary>
         /// Deletes a document matching the condition of the LINQ expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -44,6 +58,20 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>;
 
         /// <summary>
+        /// Asynchronously deletes a document matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        Task<long> DeleteOneAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null,
+            string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
+        /// <summary>
         /// Asynchronously deletes a document matching the condition of the LINQ expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -52,6 +80,19 @@ namespace MongoDbGenericRepository
         /// <param name="partitionKey">An optional partition key.</param>
         /// <returns>The number of documents deleted.</returns>
         Task<long> DeleteOneAsync<TDocument, TKey>(Expression<Func<TDocument, bool>> filter, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
+        /// <summary>
+        /// Asynchronously deletes the documents matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        Task<long> DeleteManyAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null)
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>;
 
@@ -86,6 +127,19 @@ namespace MongoDbGenericRepository
         /// <param name="documents">The list of documents to delete.</param>
         /// <returns>The number of documents deleted.</returns>
         long DeleteMany<TDocument, TKey>(IEnumerable<TDocument> documents)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+        
+        /// <summary>
+        /// Deletes the documents matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        long DeleteMany<TDocument, TKey>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null)
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>;
 
@@ -147,6 +201,19 @@ namespace MongoDbGenericRepository
         {
             return MongoDbEraser.DeleteOne<TDocument, Guid>(document);
         }
+        
+        /// <summary>
+        /// Deletes a document.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual long DeleteOne<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null) where TDocument : IDocument<Guid>
+        {
+            return MongoDbEraser.DeleteOne<TDocument, Guid>(condition, deleteOption, partitionKey).DeletedCount;
+        }
 
         /// <summary>
         /// Deletes a document matching the condition of the LINQ expression filter.
@@ -161,6 +228,20 @@ namespace MongoDbGenericRepository
         }
 
         /// <summary>
+        /// Asynchronously deletes a document matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual async Task<long> DeleteOneAsync<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null) where TDocument : IDocument<Guid>
+        {
+            var result = await MongoDbEraser.DeleteOneAsync<TDocument, Guid>(condition, deleteOption, partitionKey);
+            return result.DeletedCount;
+        }
+
+        /// <summary>
         /// Asynchronously deletes a document matching the condition of the LINQ expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -170,6 +251,20 @@ namespace MongoDbGenericRepository
         public virtual async Task<long> DeleteOneAsync<TDocument>(Expression<Func<TDocument, bool>> filter, string partitionKey = null) where TDocument : IDocument<Guid>
         {
             return await MongoDbEraser.DeleteOneAsync<TDocument, Guid>(filter, partitionKey);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes the documents matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual async Task<long> DeleteManyAsync<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null) where TDocument : IDocument<Guid>
+        {
+            var result = await MongoDbEraser.DeleteManyAsync<TDocument, Guid>(condition, deleteOption, partitionKey);
+            return result.DeletedCount;
         }
 
         /// <summary>
@@ -204,6 +299,19 @@ namespace MongoDbGenericRepository
         public virtual long DeleteMany<TDocument>(IEnumerable<TDocument> documents) where TDocument : IDocument<Guid>
         {
             return DeleteMany<TDocument, Guid>(documents);
+        }
+
+        /// <summary>
+        /// Deletes the documents matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public long DeleteMany<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null) where TDocument : IDocument<Guid>
+        {
+            return MongoDbEraser.DeleteMany<TDocument, Guid>(condition, deleteOption, partitionKey).DeletedCount;
         }
 
         /// <summary>
@@ -251,6 +359,23 @@ namespace MongoDbGenericRepository
         }
 
         /// <summary>
+        /// Deletes a document matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual long DeleteOne<TDocument, TKey>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null,
+            string partitionKey = null) 
+            where TDocument : IDocument<TKey> 
+            where TKey : IEquatable<TKey>
+        {
+            return MongoDbEraser.DeleteOne<TDocument, TKey>(condition, deleteOption, partitionKey).DeletedCount;
+        }
+
+        /// <summary>
         /// Deletes a document matching the condition of the LINQ expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -266,6 +391,24 @@ namespace MongoDbGenericRepository
         }
 
         /// <summary>
+        /// Deletes a document matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual async Task<long> DeleteOneAsync<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            DeleteOptions deleteOption = null, string partitionKey = null) 
+            where TDocument : IDocument<TKey> 
+            where TKey : IEquatable<TKey>
+        {
+            var result = await MongoDbEraser.DeleteOneAsync<TDocument, TKey>(condition, deleteOption, partitionKey);
+            return result.DeletedCount;
+        }
+
+        /// <summary>
         /// Asynchronously deletes a document matching the condition of the LINQ expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -278,6 +421,24 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>
         {
             return await MongoDbEraser.DeleteOneAsync<TDocument, TKey>(filter, partitionKey);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes the documents matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual async Task<long> DeleteManyAsync<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            DeleteOptions deleteOption = null, string partitionKey = null) 
+            where TDocument : IDocument<TKey> 
+            where TKey : IEquatable<TKey>
+        {
+            var result = await MongoDbEraser.DeleteManyAsync<TDocument, TKey>(condition, deleteOption, partitionKey);
+            return result.DeletedCount;
         }
 
         /// <summary>
@@ -321,6 +482,20 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>
         {
             return MongoDbEraser.DeleteMany<TDocument, TKey>(documents);
+        }
+
+        /// <summary>
+        /// Deletes the documents matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual long DeleteMany<TDocument, TKey>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbEraser.DeleteMany<TDocument, TKey>(condition, deleteOption, partitionKey).DeletedCount;
         }
 
         /// <summary>

--- a/MongoDbGenericRepository/BaseMongoRepository.Main.cs
+++ b/MongoDbGenericRepository/BaseMongoRepository.Main.cs
@@ -24,7 +24,7 @@ namespace MongoDbGenericRepository
         }
 
         /// <summary>
-        /// The contructor taking a <see cref="IMongoDbContext"/>.
+        /// The constructor taking a <see cref="IMongoDbContext"/>.
         /// </summary>
         /// <param name="mongoDbContext">A mongodb context implementing <see cref="IMongoDbContext"/></param>
         protected BaseMongoRepository(IMongoDbContext mongoDbContext) : base(mongoDbContext)
@@ -32,11 +32,26 @@ namespace MongoDbGenericRepository
         }
 
         /// <summary>
-        /// The contructor taking a <see cref="IMongoDatabase"/>.
+        /// The constructor taking a <see cref="IMongoDatabase"/>.
         /// </summary>
         /// <param name="mongoDatabase">A mongodb context implementing <see cref="IMongoDatabase"/></param>
         protected BaseMongoRepository(IMongoDatabase mongoDatabase) : base(mongoDatabase)
         {
+        }
+
+        /// <summary>
+        /// Asynchronously returns a paginated list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="skipNumber">The number of documents you want to skip. Default value is 0.</param>
+        /// <param name="takeNumber">The number of documents you want to take. Default value is 50.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual Task<List<TDocument>> GetPaginatedAsync<TDocument>(FilterDefinition<TDocument> condition, FindOptions findOption = null, int skipNumber = 0, int takeNumber = 50,
+            string partitionKey = null) where TDocument : IDocument
+        {
+            return HandlePartitioned<TDocument>(partitionKey).Find(condition, findOption).Skip(skipNumber).Limit(takeNumber).ToListAsync();
         }
 
         /// <summary>
@@ -55,6 +70,22 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument
         {
             return await HandlePartitioned<TDocument>(partitionKey).Find(filter).Skip(skipNumber).Limit(takeNumber).ToListAsync();
+        }
+
+        /// <summary>
+        /// Asynchronously returns a paginated list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="skipNumber">The number of documents you want to skip. Default value is 0.</param>
+        /// <param name="takeNumber">The number of documents you want to take. Default value is 50.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual Task<List<TDocument>> GetPaginatedAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null, int skipNumber = 0, int takeNumber = 50,
+            string partitionKey = null) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption).Skip(skipNumber).Limit(takeNumber).ToListAsync();
         }
 
         /// <summary>

--- a/MongoDbGenericRepository/DataAccess/Base/DataAccessBase.cs
+++ b/MongoDbGenericRepository/DataAccess/Base/DataAccessBase.cs
@@ -132,6 +132,24 @@ namespace MongoDbGenericRepository.DataAccess.Base
             };
         }
 
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        protected virtual IFindFluent<TDocument, TDocument> GetMinMongoQuery<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, TValue>> minValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetCollection<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .SortBy(ConvertExpression(minValueSelector))
+                .Limit(1);
+        }
 
         /// <summary>
         /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
@@ -151,6 +169,25 @@ namespace MongoDbGenericRepository.DataAccess.Base
                                                                .Limit(1);
         }
 
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        protected virtual IFindFluent<TDocument, TDocument> GetMaxMongoQuery<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, TValue>> maxValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetCollection<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .SortByDescending(ConvertExpression(maxValueSelector))
+                .Limit(1);
+        }
+        
         /// <summary>
         /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
         /// </summary>

--- a/MongoDbGenericRepository/DataAccess/Delete/MongoDbEraser.cs
+++ b/MongoDbGenericRepository/DataAccess/Delete/MongoDbEraser.cs
@@ -49,6 +49,23 @@ namespace MongoDbGenericRepository.DataAccess.Delete
         }
 
         /// <summary>
+        /// Deletes a document matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual DeleteResult DeleteOne<TDocument, TKey>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null,
+            string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).DeleteOne(condition, deleteOption);
+        }
+        
+        /// <summary>
         /// Deletes a document matching the condition of the LINQ expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -68,6 +85,22 @@ namespace MongoDbGenericRepository.DataAccess.Delete
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual Task<DeleteResult> DeleteOneAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).DeleteOneAsync(condition, deleteOption);
+        }
+        
+        /// <summary>
+        /// Asynchronously deletes a document matching the condition of the LINQ expression filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         /// <returns>The number of documents deleted.</returns>
@@ -78,6 +111,23 @@ namespace MongoDbGenericRepository.DataAccess.Delete
             return (await HandlePartitioned<TDocument, TKey>(partitionKey).DeleteOneAsync(filter)).DeletedCount;
         }
 
+        /// <summary>
+        /// Asynchronously deletes the documents matching the condition of the LINQ expression filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual Task<DeleteResult> DeleteManyAsync<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            DeleteOptions deleteOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).DeleteManyAsync(condition, deleteOption);
+        }
+        
         /// <summary>
         /// Asynchronously deletes the documents matching the condition of the LINQ expression filter.
         /// </summary>
@@ -159,6 +209,23 @@ namespace MongoDbGenericRepository.DataAccess.Delete
             }
         }
 
+        /// <summary>
+        /// Deletes the documents matching the condition of the LINQ expression filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual DeleteResult DeleteMany<TDocument, TKey>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null,
+            string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).DeleteMany(condition, deleteOption);
+        }
+        
         /// <summary>
         /// Deletes the documents matching the condition of the LINQ expression filter.
         /// </summary>

--- a/MongoDbGenericRepository/DataAccess/Read/MongoDbReader.Main.cs
+++ b/MongoDbGenericRepository/DataAccess/Read/MongoDbReader.Main.cs
@@ -124,6 +124,22 @@ namespace MongoDbGenericRepository.DataAccess.Read
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual IFindFluent<TDocument, TDocument> GetCursor<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null,
+            string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption);
+        }
+
+        /// <summary>
+        /// Returns a collection cursor.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         public virtual IFindFluent<TDocument, TDocument> GetCursor<TDocument, TKey>(Expression<Func<TDocument, bool>> filter, string partitionKey = null)
@@ -332,6 +348,28 @@ namespace MongoDbGenericRepository.DataAccess.Read
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TDocument> GetByMaxAsync<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> maxValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetCollection<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .SortByDescending(maxValueSelector)
+                .Limit(1)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="maxValueSelector">A property selector to order by descending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -344,6 +382,25 @@ namespace MongoDbGenericRepository.DataAccess.Read
                                                                      .SortByDescending(maxValueSelector)
                                                                      .Limit(1)
                                                                      .FirstOrDefaultAsync(cancellationToken);
+        }
+        
+        /// <summary>
+        /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        public virtual TDocument GetByMax<TDocument, TKey>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, object>> maxValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetCollection<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .SortByDescending(maxValueSelector)
+                .Limit(1)
+                .FirstOrDefault();
         }
 
         /// <summary>
@@ -369,6 +426,28 @@ namespace MongoDbGenericRepository.DataAccess.Read
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TDocument> GetByMinAsync<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> minValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetCollection<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .SortBy(minValueSelector)
+                .Limit(1)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+        
+        /// <summary>
+        /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="minValueSelector">A property selector to order by ascending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -388,6 +467,26 @@ namespace MongoDbGenericRepository.DataAccess.Read
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        public virtual TDocument GetByMin<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> minValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetCollection<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .SortBy(minValueSelector)
+                .Limit(1)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="minValueSelector">A property selector to order by ascending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -399,6 +498,28 @@ namespace MongoDbGenericRepository.DataAccess.Read
                                                                .SortBy(minValueSelector)
                                                                .Limit(1)
                                                                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets the maximum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the field for which you want the maximum value.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TValue> GetMaxValueAsync<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> maxValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetMaxMongoQuery<TDocument, TKey, TValue>(condition, maxValueSelector, findOption, partitionKey)
+                .Project(maxValueSelector)
+                .FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <summary>
@@ -426,6 +547,25 @@ namespace MongoDbGenericRepository.DataAccess.Read
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        public virtual TValue GetMaxValue<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, TValue>> maxValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetMaxMongoQuery<TDocument, TKey, TValue>(condition, maxValueSelector, findOption, partitionKey)
+                .Project(maxValueSelector)
+                .FirstOrDefault();
+        }
+        
+        /// <summary>
+        /// Gets the maximum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="maxValueSelector">A property selector to order by ascending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -444,6 +584,27 @@ namespace MongoDbGenericRepository.DataAccess.Read
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TValue> GetMinValueAsync<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> minValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetMinMongoQuery<TDocument, TKey, TValue>(condition, minValueSelector, findOption, partitionKey)
+                .Project(minValueSelector).FirstOrDefaultAsync(cancellationToken);
+        }
+        
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="minValueSelector">A property selector to order by ascending.</param>
         /// <param name="partitionKey">An optional partition key.</param>
@@ -455,6 +616,25 @@ namespace MongoDbGenericRepository.DataAccess.Read
             return await GetMinMongoQuery<TDocument, TKey, TValue>(filter, minValueSelector, partitionKey).Project(minValueSelector).FirstOrDefaultAsync(cancellationToken);
         }
 
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual TValue GetMinValue<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> minValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetMinMongoQuery<TDocument, TKey, TValue>(condition, minValueSelector, findOption, partitionKey)
+                .Project(minValueSelector).FirstOrDefault();
+        }
+        
         /// <summary>
         /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
         /// </summary>

--- a/MongoDbGenericRepository/DataAccess/Read/MongoDbReader.Project.cs
+++ b/MongoDbGenericRepository/DataAccess/Read/MongoDbReader.Project.cs
@@ -18,6 +18,58 @@ namespace MongoDbGenericRepository.DataAccess.Read
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TProjection> ProjectOneAsync<TDocument, TProjection, TKey>(
+            FilterDefinition<TDocument> condition, 
+            ProjectionDefinition<TDocument, TProjection> projection,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .Project(projection)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+        
+        /// <summary>
+        /// Asynchronously returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TProjection> ProjectOneAsync<TDocument, TProjection, TKey>(
+            FilterDefinition<TDocument> condition, 
+            Expression<Func<TDocument, TProjection>> projection,
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .Project(projection)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+        
+        /// <summary>
+        /// Asynchronously returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="projection">The projection expression.</param>
         /// <param name="partitionKey">An optional partition key.</param>
@@ -36,6 +88,48 @@ namespace MongoDbGenericRepository.DataAccess.Read
                                                                          .FirstOrDefaultAsync(cancellationToken);
         }
 
+        /// <summary>
+        /// Returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual TProjection ProjectOne<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .Project(projection)
+                .FirstOrDefault();
+        }
+        
+        /// <summary>
+        /// Returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual TProjection ProjectOne<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .Project(projection)
+                .FirstOrDefault();
+        }
+        
         /// <summary>
         /// Returns a projected document matching the filter condition.
         /// </summary>
@@ -61,6 +155,58 @@ namespace MongoDbGenericRepository.DataAccess.Read
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection, TKey>(
+            FilterDefinition<TDocument> condition, 
+            ProjectionDefinition<TDocument, TProjection> projection, 
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .Project(projection)
+                .ToListAsync(cancellationToken);
+        }
+        
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection, TKey>(
+            FilterDefinition<TDocument> condition, 
+            Expression<Func<TDocument, TProjection>> projection, 
+            FindOptions findOption = null,
+            string partitionKey = null,
+            CancellationToken cancellationToken = default)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .Project(projection)
+                .ToListAsync(cancellationToken);
+        }
+        
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="projection">The projection expression.</param>
         /// <param name="partitionKey">An optional partition key.</param>
@@ -79,6 +225,48 @@ namespace MongoDbGenericRepository.DataAccess.Read
                                                                    .ToListAsync(cancellationToken);
         }
 
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual List<TProjection> ProjectMany<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .Project(projection)
+                .ToList();
+        }
+        
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual List<TProjection> ProjectMany<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+            where TProjection : class
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey).Find(condition, findOption)
+                .Project(projection)
+                .ToList();
+        }
+        
         /// <summary>
         /// Asynchronously returns a list of projected documents matching the filter condition.
         /// </summary>

--- a/MongoDbGenericRepository/KeyTypedRepository/BaseMongoRepository.TKey.Delete.cs
+++ b/MongoDbGenericRepository/KeyTypedRepository/BaseMongoRepository.TKey.Delete.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using MongoDB.Driver;
 
 namespace MongoDbGenericRepository
 {
@@ -32,6 +33,17 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>;
 
         /// <summary>
+        /// Deletes a document matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        long DeleteOne<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>;
+        
+        /// <summary>
         /// Deletes a document matching the condition of the LINQ expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -39,6 +51,17 @@ namespace MongoDbGenericRepository
         /// <param name="partitionKey">An optional partition key.</param>
         /// <returns>The number of documents deleted.</returns>
         long DeleteOne<TDocument>(Expression<Func<TDocument, bool>> filter, string partitionKey = null)
+            where TDocument : IDocument<TKey>;
+        
+        /// <summary>
+        /// Asynchronously deletes a document matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        Task<long> DeleteOneAsync<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null)
             where TDocument : IDocument<TKey>;
 
         /// <summary>
@@ -49,6 +72,17 @@ namespace MongoDbGenericRepository
         /// <param name="partitionKey">An optional partition key.</param>
         /// <returns>The number of documents deleted.</returns>
         Task<long> DeleteOneAsync<TDocument>(Expression<Func<TDocument, bool>> filter, string partitionKey = null)
+            where TDocument : IDocument<TKey>;
+
+        /// <summary>
+        /// Asynchronously deletes the documents matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        Task<long> DeleteManyAsync<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null)
             where TDocument : IDocument<TKey>;
 
         /// <summary>
@@ -79,6 +113,18 @@ namespace MongoDbGenericRepository
         long DeleteMany<TDocument>(IEnumerable<TDocument> documents)
             where TDocument : IDocument<TKey>;
 
+        /// <summary>
+        /// Deletes the documents matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        long DeleteMany<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>;
+        
         /// <summary>
         /// Deletes the documents matching the condition of the LINQ expression filter.
         /// </summary>
@@ -141,6 +187,20 @@ namespace MongoDbGenericRepository
         }
 
         /// <summary>
+        /// Deletes a document matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual long DeleteOne<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null,
+            string partitionKey = null) where TDocument : IDocument<TKey>
+        {
+            return MongoDbEraser.DeleteOne<TDocument, TKey>(condition, deleteOption, partitionKey).DeletedCount;
+        }
+
+        /// <summary>
         /// Deletes a document matching the condition of the LINQ expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -154,6 +214,20 @@ namespace MongoDbGenericRepository
         }
 
         /// <summary>
+        /// Deletes a document matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual async Task<long> DeleteOneAsync<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null) where TDocument : IDocument<TKey>
+        {
+            var result = await MongoDbEraser.DeleteOneAsync<TDocument, TKey>(condition, deleteOption, partitionKey);
+            return result.DeletedCount;
+        }
+
+        /// <summary>
         /// Asynchronously deletes a document matching the condition of the LINQ expression filter.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
@@ -164,6 +238,21 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
         {
             return await MongoDbEraser.DeleteOneAsync<TDocument, TKey>(filter, partitionKey);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes the documents matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public virtual async Task<long> DeleteManyAsync<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null,
+            string partitionKey = null) where TDocument : IDocument<TKey>
+        {
+            var result = await MongoDbEraser.DeleteManyAsync<TDocument, TKey>(condition, deleteOption, partitionKey);
+            return result.DeletedCount;
         }
 
         /// <summary>
@@ -201,6 +290,19 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
         {
             return MongoDbEraser.DeleteMany<TDocument, TKey>(documents);
+        }
+
+        /// <summary>
+        /// Deletes the documents matching the condition of the filter definition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="deleteOption">A mongodb delete option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <returns>The number of documents deleted.</returns>
+        public long DeleteMany<TDocument>(FilterDefinition<TDocument> condition, DeleteOptions deleteOption = null, string partitionKey = null) where TDocument : IDocument<TKey>
+        {
+            return MongoDbEraser.DeleteMany<TDocument, TKey>(condition, deleteOption, partitionKey).DeletedCount;
         }
 
         /// <summary>

--- a/MongoDbGenericRepository/KeyTypedRepository/BaseMongoRepository.TKey.ReadOnly.cs
+++ b/MongoDbGenericRepository/KeyTypedRepository/BaseMongoRepository.TKey.ReadOnly.cs
@@ -131,6 +131,18 @@ namespace MongoDbGenericRepository
         /// Returns a collection cursor.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public IFindFluent<TDocument, TDocument> GetCursor<TDocument>(FilterDefinition<TDocument> condition, FindOptions findOption = null, string partitionKey = null) where TDocument : IDocument<TKey>
+        {
+            return MongoDbReader.GetCursor<TDocument, TKey>(condition, findOption, partitionKey);
+        }
+
+        /// <summary>
+        /// Returns a collection cursor.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         public IFindFluent<TDocument, TDocument> GetCursor<TDocument>(Expression<Func<TDocument, bool>> filter, string partitionKey = null) where TDocument : IDocument<TKey>
@@ -208,6 +220,23 @@ namespace MongoDbGenericRepository
         /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TDocument> GetByMaxAsync<TDocument>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> maxValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey>
+        {
+            return MongoDbReader.GetByMaxAsync<TDocument, TKey>(condition, maxValueSelector, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="maxValueSelector">A property selector to order by descending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -215,6 +244,21 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
         {
             return await MongoDbReader.GetByMaxAsync<TDocument, TKey>(filter, maxValueSelector, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        public virtual TDocument GetByMax<TDocument>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, object>> maxValueSelector,
+            FindOptions findOption = null, string partitionKey = null) 
+            where TDocument : IDocument<TKey>
+        {
+            return MongoDbReader.GetByMax<TDocument, TKey>(condition, maxValueSelector, findOption, partitionKey);
         }
 
         /// <summary>
@@ -232,6 +276,23 @@ namespace MongoDbGenericRepository
         }
 
         /// <summary>
+        /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TDocument> GetByMinAsync<TDocument>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> minValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey>
+        {
+            return MongoDbReader.GetByMinAsync<TDocument, TKey>(condition, minValueSelector, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
         /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
@@ -245,6 +306,20 @@ namespace MongoDbGenericRepository
         }
 
         /// <summary>
+        /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        public virtual TDocument GetByMin<TDocument>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, object>> minValueSelector,
+            FindOptions findOption = null, string partitionKey = null) where TDocument : IDocument<TKey>
+        {
+            return MongoDbReader.GetByMin<TDocument, TKey>(condition, minValueSelector, findOption, partitionKey);
+        }
+
+        /// <summary>
         /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
@@ -255,6 +330,24 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
         {
             return MongoDbReader.GetByMin<TDocument, TKey>(filter, minValueSelector, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets the maximum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TValue">The type of the field for which you want the maximum value.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TValue> GetMaxValueAsync<TDocument, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> maxValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey>
+        {
+            return MongoDbReader.GetMaxValueAsync<TDocument, TKey, TValue>(condition, maxValueSelector, findOption, partitionKey, cancellationToken);
         }
 
         /// <summary>
@@ -276,6 +369,22 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        public virtual TValue GetMaxValue<TDocument, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> maxValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+        {
+            return MongoDbReader.GetMaxValue<TDocument, TKey, TValue>(condition, maxValueSelector, findOption, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets the maximum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="maxValueSelector">A property selector to order by ascending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -283,6 +392,25 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
         {
             return MongoDbReader.GetMaxValue<TDocument, TKey, TValue>(filter, maxValueSelector, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TValue> GetMinValueAsync<TDocument, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> minValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey>
+        {
+            return MongoDbReader.GetMinValueAsync<TDocument, TKey, TValue>(condition, minValueSelector, findOption, partitionKey, cancellationToken);
         }
 
         /// <summary>
@@ -297,6 +425,22 @@ namespace MongoDbGenericRepository
             where TDocument : IDocument<TKey>
         {
             return await MongoDbReader.GetMinValueAsync<TDocument, TKey, TValue>(filter, minValueSelector, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual TValue GetMinValue<TDocument, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> minValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+        {
+            return MongoDbReader.GetMinValue<TDocument, TKey, TValue>(condition, minValueSelector, findOption, partitionKey);
         }
 
         /// <summary>
@@ -385,6 +529,44 @@ namespace MongoDbGenericRepository
         /// Asynchronously returns a projected document matching the filter condition.
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TProjection> ProjectOneAsync<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey> 
+            where TProjection : class
+        {
+            return MongoDbReader.ProjectOneAsync<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TProjection> ProjectOneAsync<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey> 
+            where TProjection : class
+        {
+            return MongoDbReader.ProjectOneAsync<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
@@ -395,6 +577,40 @@ namespace MongoDbGenericRepository
             where TProjection : class
         {
             return await MongoDbReader.ProjectOneAsync<TDocument, TProjection, TKey>(filter, projection, partitionKey);
+        }
+
+        /// <summary>
+        /// Returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual TProjection ProjectOne<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> 
+            where TProjection : class
+        {
+            return MongoDbReader.ProjectOne<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey);
+        }
+
+        /// <summary>
+        /// Returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual TProjection ProjectOne<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> 
+            where TProjection : class
+        {
+            return MongoDbReader.ProjectOne<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey);
         }
 
         /// <summary>
@@ -417,6 +633,44 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey> 
+            where TProjection : class
+        {
+            return MongoDbReader.ProjectManyAsync<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey> 
+            where TProjection : class
+        {
+            return MongoDbReader.ProjectManyAsync<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="projection">The projection expression.</param>
         /// <param name="partitionKey">An optional partition key.</param>
@@ -425,6 +679,40 @@ namespace MongoDbGenericRepository
             where TProjection : class
         {
             return await MongoDbReader.ProjectManyAsync<TDocument, TProjection, TKey>(filter, projection, partitionKey);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A project definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public List<TProjection> ProjectMany<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> 
+            where TProjection : class
+        {
+            return MongoDbReader.ProjectMany<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public List<TProjection> ProjectMany<TDocument, TProjection>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> 
+            where TProjection : class
+        {
+            return MongoDbReader.ProjectMany<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey);
         }
 
         /// <summary>

--- a/MongoDbGenericRepository/ReadOnlyMongoRepository.cs
+++ b/MongoDbGenericRepository/ReadOnlyMongoRepository.cs
@@ -135,6 +135,19 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual IFindFluent<TDocument, TDocument> GetCursor<TDocument, TKey>(FilterDefinition<TDocument> condition, FindOptions findOption = null, string partitionKey = null) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetCursor<TDocument, TKey>(condition, findOption, partitionKey);
+        }
+
+        /// <summary>
+        /// Returns a collection cursor.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="partitionKey">An optional partition key.</param>
         public virtual IFindFluent<TDocument, TDocument> GetCursor<TDocument, TKey>(Expression<Func<TDocument, bool>> filter, string partitionKey = null)
@@ -322,6 +335,22 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TDocument> GetByMaxAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, object>> maxValueSelector, FindOptions findOption = null,
+            string partitionKey = null, CancellationToken cancellationToken = default) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetByMaxAsync<TDocument, TKey>(condition, maxValueSelector, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="maxValueSelector">A property selector to order by descending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -341,6 +370,22 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by descending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        public virtual TDocument GetByMax<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> maxValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetByMax<TDocument, TKey>(condition, maxValueSelector, findOption, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets the document with the maximum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="maxValueSelector">A property selector to order by descending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -349,6 +394,23 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>
         {
             return MongoDbReader.GetByMax<TDocument, TKey>(filter, maxValueSelector, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector for the minimum value you are looking for.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TDocument> GetByMinAsync<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> minValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetByMinAsync<TDocument, TKey>(condition, minValueSelector, findOption, partitionKey, cancellationToken);
         }
 
         /// <summary>
@@ -375,6 +437,22 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector for the minimum value you are looking for.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        public virtual TDocument GetByMin<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> minValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetByMin<TDocument, TKey>(condition, minValueSelector, findOption, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets the document with the minimum value of a specified property in a MongoDB collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="minValueSelector">A property selector for the minimum value you are looking for.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -383,6 +461,13 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>
         {
             return MongoDbReader.GetByMin<TDocument, TKey>(filter, minValueSelector, partitionKey);
+        }
+
+        public virtual Task<TValue> GetMaxValueAsync<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> maxValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetMaxValueAsync<TDocument, TKey, TValue>(condition, maxValueSelector, findOption, partitionKey, cancellationToken);
         }
 
         /// <summary>
@@ -412,6 +497,23 @@ namespace MongoDbGenericRepository
         /// <typeparam name="TDocument">The document type.</typeparam>
         /// <typeparam name="TKey">The type of the primary key.</typeparam>
         /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="maxValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partitionKey.</param>
+        public virtual TValue GetMaxValue<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> maxValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetMaxValue<TDocument, TKey, TValue>(condition, maxValueSelector, findOption, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets the maximum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="maxValueSelector">A property selector to order by ascending.</param>
         /// <param name="partitionKey">An optional partitionKey.</param>
@@ -420,6 +522,24 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>
         {
             return MongoDbReader.GetMaxValue<TDocument, TKey, TValue>(filter, maxValueSelector, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TValue> GetMinValueAsync<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> minValueSelector, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetMinValueAsync<TDocument, TKey, TValue>(condition, minValueSelector, findOption, partitionKey, cancellationToken);
         }
 
         /// <summary>
@@ -441,6 +561,23 @@ namespace MongoDbGenericRepository
             where TKey : IEquatable<TKey>
         {
             return await MongoDbReader.GetMinValueAsync<TDocument, TKey, TValue>(filter, minValueSelector, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the minimum value of a property in a mongodb collections that is satisfying the filter.
+        /// </summary>
+        /// <typeparam name="TDocument">The document type.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key.</typeparam>
+        /// <typeparam name="TValue">The type of the value used to order the query.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="minValueSelector">A property selector to order by ascending.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public TValue GetMinValue<TDocument, TKey, TValue>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TValue>> minValueSelector, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.GetMinValue<TDocument, TKey, TValue>(condition, minValueSelector, findOption, partitionKey);
         }
 
         /// <summary>
@@ -543,6 +680,48 @@ namespace MongoDbGenericRepository
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A projection definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TProjection> ProjectOneAsync<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey>
+            where TProjection : class
+            where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.ProjectOneAsync<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<TProjection> ProjectOneAsync<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey>
+            where TProjection : class
+            where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.ProjectOneAsync<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="projection">The projection expression.</param>
         /// <param name="partitionKey">An optional partition key.</param>
@@ -557,6 +736,44 @@ namespace MongoDbGenericRepository
             where TProjection : class
         {
             return await MongoDbReader.ProjectOneAsync<TDocument, TProjection, TKey>(filter, projection, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A projection definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual TProjection ProjectOne<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> 
+            where TProjection : class 
+            where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.ProjectOne<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey);
+        }
+
+        /// <summary>
+        /// Returns a projected document matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual TProjection ProjectOne<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> 
+            where TProjection : class 
+            where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.ProjectOne<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey);
         }
 
         /// <summary>
@@ -582,6 +799,48 @@ namespace MongoDbGenericRepository
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A projection definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey>
+            where TProjection : class
+            where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.ProjectManyAsync<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<List<TProjection>> ProjectManyAsync<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null, string partitionKey = null,
+            CancellationToken cancellationToken = default) 
+            where TDocument : IDocument<TKey>
+            where TProjection : class
+            where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.ProjectManyAsync<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="projection">The projection expression.</param>
         /// <param name="partitionKey">An optional partition key.</param>
@@ -595,6 +854,41 @@ namespace MongoDbGenericRepository
             where TProjection : class
         {
             return await MongoDbReader.ProjectManyAsync<TDocument, TProjection, TKey>(filter, projection, partitionKey, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">A projection definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual List<TProjection> ProjectMany<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition,
+            ProjectionDefinition<TDocument, TProjection> projection, FindOptions findOption = null, string partitionKey = null)
+            where TDocument : IDocument<TKey> 
+            where TProjection : class 
+            where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.ProjectMany<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a list of projected documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <typeparam name="TProjection">The type representing the model you want to project to.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="projection">The projection expression.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual List<TProjection> ProjectMany<TDocument, TProjection, TKey>(FilterDefinition<TDocument> condition, Expression<Func<TDocument, TProjection>> projection, FindOptions findOption = null,
+            string partitionKey = null) where TDocument : IDocument<TKey> where TProjection : class where TKey : IEquatable<TKey>
+        {
+            return MongoDbReader.ProjectMany<TDocument, TProjection, TKey>(condition, projection, findOption, partitionKey);
         }
 
         /// <summary>
@@ -666,8 +960,35 @@ namespace MongoDbGenericRepository
 
         #endregion Group By TKey
 
-
         #region Pagination
+
+        /// <summary>
+        /// Asynchronously returns a paginated list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="sortSelector">The property selector.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="ascending">Order of the sorting.</param>
+        /// <param name="skipNumber">The number of documents you want to skip. Default value is 0.</param>
+        /// <param name="takeNumber">The number of documents you want to take. Default value is 50.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        public virtual Task<List<TDocument>> GetSortedPaginatedAsync<TDocument, TKey>(FilterDefinition<TDocument> condition,
+            Expression<Func<TDocument, object>> sortSelector, FindOptions findOption = null, bool ascending = true, int skipNumber = 0,
+            int takeNumber = 50, string partitionKey = null) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            var sorting = ascending
+                ? Builders<TDocument>.Sort.Ascending(sortSelector)
+                : Builders<TDocument>.Sort.Descending(sortSelector);
+
+            return HandlePartitioned<TDocument, TKey>(partitionKey)
+                .Find(condition, findOption)
+                .Sort(sorting)
+                .Skip(skipNumber)
+                .Limit(takeNumber)
+                .ToListAsync();
+        }
 
         /// <summary>
         /// Asynchronously returns a paginated list of the documents matching the filter condition.
@@ -707,6 +1028,29 @@ namespace MongoDbGenericRepository
         /// </summary>
         /// <typeparam name="TDocument">The type representing a Document.</typeparam>
         /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
+        /// <param name="condition">A mongodb filter definition.</param>
+        /// <param name="sortDefinition">The sort definition.</param>
+        /// <param name="findOption">A mongodb filter option.</param>
+        /// <param name="skipNumber">The number of documents you want to skip. Default value is 0.</param>
+        /// <param name="takeNumber">The number of documents you want to take. Default value is 50.</param>
+        /// <param name="partitionKey">An optional partition key.</param>
+        /// <param name="cancellationToken">An optional cancellation Token.</param>
+        public virtual Task<List<TDocument>> GetSortedPaginatedAsync<TDocument, TKey>(FilterDefinition<TDocument> condition, SortDefinition<TDocument> sortDefinition, FindOptions findOption = null,
+            int skipNumber = 0, int takeNumber = 50, string partitionKey = null, CancellationToken cancellationToken = default) where TDocument : IDocument<TKey> where TKey : IEquatable<TKey>
+        {
+            return HandlePartitioned<TDocument, TKey>(partitionKey)
+                .Find(condition, findOption)
+                .Sort(sortDefinition)
+                .Skip(skipNumber)
+                .Limit(takeNumber)
+                .ToListAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a paginated list of the documents matching the filter condition.
+        /// </summary>
+        /// <typeparam name="TDocument">The type representing a Document.</typeparam>
+        /// <typeparam name="TKey">The type of the primary key for a Document.</typeparam>
         /// <param name="filter">A LINQ expression filter.</param>
         /// <param name="sortDefinition">The sort definition.</param>
         /// <param name="skipNumber">The number of documents you want to skip. Default value is 0.</param>
@@ -732,8 +1076,6 @@ namespace MongoDbGenericRepository
         }
 
         #endregion Pagination
-
-
 
         /// <summary>
         /// Gets a collections for a potentially partitioned document type.


### PR DESCRIPTION
I was not touch the update part yet because we make use of native mongodb operation already, but lacking of `UpdateOptions`.

I was planning to mark them as obsolete so we can drop them later, and copy all of current operation to new method that include `UpdateOptions`.

Was that fine ?