### PR TITLE
Bumped mongodb.driver to 2.15

### DIFF
--- a/MongoDbGenericRepository/MongoDbGenericRepository.csproj
+++ b/MongoDbGenericRepository/MongoDbGenericRepository.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0;netstandard1.5;</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;</TargetFrameworks>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>MongoDbGenericRepository</PackageId>
     <PackageVersion>1.4.8</PackageVersion>
@@ -25,7 +25,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.13.2" />
+    <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hey, thanks for maintaining this package, it's super useful!

I've bumped the MongoDB.Driver package to 2.15, as it's needed to use MongoDB 5.2. This required dropping support for netstandard1.5 and bumping net452 target to 472. Let me know if any other changes would be required ☺️