### PR TITLE
update driver to 2.28

### DIFF
--- a/CoreIntegrationTests/CoreIntegrationTests.csproj
+++ b/CoreIntegrationTests/CoreIntegrationTests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="2.1.2" />
-    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.console" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>

--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -55,17 +55,17 @@
     <Reference Include="Microsoft.Win32.Registry, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Registry.5.0.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=2.20.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Bson.2.20.0\lib\net472\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.28.0.0, Culture=neutral, PublicKeyToken=94992a530f44e321, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.28.0\lib\net472\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=2.18.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.2.18.0\lib\net472\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.28.0.0, Culture=neutral, PublicKeyToken=94992a530f44e321, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.28.0\lib\net472\MongoDB.Driver.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver.Core, Version=2.20.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.Core.2.20.0\lib\net472\MongoDB.Driver.Core.dll</HintPath>
+    <Reference Include="MongoDB.Driver.Core, Version=2.28.0.0, Culture=neutral, PublicKeyToken=94992a530f44e321, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.28.0\lib\net472\MongoDB.Driver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Libmongocrypt, Version=1.9.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Libmongocrypt.1.9.0\lib\netstandard2.0\MongoDB.Libmongocrypt.dll</HintPath>
+    <Reference Include="MongoDB.Libmongocrypt, Version=1.11.0.0, Culture=neutral, PublicKeyToken=94992a530f44e321, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Libmongocrypt.1.11.0\lib\net472\MongoDB.Libmongocrypt.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="nunit.framework, Version=3.13.2.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
@@ -167,6 +167,8 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="libmongocrypt.dylib" />
+    <None Include="libmongocrypt.so" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -182,8 +184,6 @@
     <Analyzer Include="..\packages\AWSSDK.SecurityToken.3.7.100.14\analyzers\dotnet\cs\AWSSDK.SecurityToken.CodeAnalysis.dll" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="libmongocrypt.dylib" />
-    <Content Include="libmongocrypt.so" />
     <Content Include="mongocrypt.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -193,7 +193,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NUnit.3.13.2\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.2\build\NUnit.props'))" />
     <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.0.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.0.0\build\net35\NUnit3TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MongoDB.Libmongocrypt.1.9.0\build\MongoDB.Libmongocrypt.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MongoDB.Libmongocrypt.1.9.0\build\MongoDB.Libmongocrypt.targets'))" />
+    <Error Condition="!Exists('..\packages\MongoDB.Libmongocrypt.1.11.0\build\MongoDB.Libmongocrypt.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MongoDB.Libmongocrypt.1.11.0\build\MongoDB.Libmongocrypt.targets'))" />
   </Target>
-  <Import Project="..\packages\MongoDB.Libmongocrypt.1.9.0\build\MongoDB.Libmongocrypt.targets" Condition="Exists('..\packages\MongoDB.Libmongocrypt.1.9.0\build\MongoDB.Libmongocrypt.targets')" />
+  <Import Project="..\packages\MongoDB.Libmongocrypt.1.11.0\build\MongoDB.Libmongocrypt.targets" Condition="Exists('..\packages\MongoDB.Libmongocrypt.1.11.0\build\MongoDB.Libmongocrypt.targets')" />
 </Project>

--- a/IntegrationTests/packages.config
+++ b/IntegrationTests/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MongoDB.Driver.Core" version="2.25.0" targetFramework="net48" />
-  <package id="MongoDB.Libmongocrypt" version="1.9.0" targetFramework="net48" />
   <package id="AWSSDK.Core" version="3.7.100.14" targetFramework="net48" />
   <package id="AWSSDK.SecurityToken" version="3.7.100.14" targetFramework="net48" />
   <package id="Crc32C.NET" version="1.0.5.0" targetFramework="net461" />
@@ -9,8 +7,10 @@
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net48" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" targetFramework="net48" />
   <package id="Microsoft.Win32.Registry" version="5.0.0" targetFramework="net48" />
-  <package id="MongoDB.Bson" version="2.25.0" targetFramework="net48" />
-  <package id="MongoDB.Driver" version="2.25.0" targetFramework="net48" />
+  <package id="MongoDB.Bson" version="2.28.0" targetFramework="net48" />
+  <package id="MongoDB.Driver" version="2.28.0" targetFramework="net48" />
+  <package id="MongoDB.Driver.Core" version="2.28.0" targetFramework="net48" />
+  <package id="MongoDB.Libmongocrypt" version="1.11.0" targetFramework="net48" />
   <package id="NUnit" version="3.13.2" targetFramework="net461" />
   <package id="NUnit.ConsoleRunner" version="3.12.0" targetFramework="net461" />
   <package id="NUnit3TestAdapter" version="4.0.0" targetFramework="net461" />

--- a/MongoDbGenericRepository/MongoDbGenericRepository.csproj
+++ b/MongoDbGenericRepository/MongoDbGenericRepository.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net472;netstandard2.0;</TargetFrameworks>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>MongoDbGenericRepository</PackageId>
-    <PackageVersion>1.6.0</PackageVersion>
+    <PackageVersion>1.6.2</PackageVersion>
     <Authors>Alexandre Spieser</Authors>
     <PackageTitle>MongoDb Generic Repository</PackageTitle>
     <Description>A generic repository implementation using the MongoDB C# Sharp 2.0 driver.</Description>
@@ -15,7 +15,7 @@
     <Copyright>Copyright 2023 (c) Alexandre Spieser. All rights reserved.</Copyright>
     <PackageTags>MongoDb Repository Generic NoSql</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.6.0</Version>
+    <Version>1.6.2</Version>
     <RepositoryUrl>https://github.com/alexandre-spieser/mongodb-generic-repository</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
   </PropertyGroup>
@@ -25,7 +25,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Addressing 2.28 upgrade request without dropping legacy target framework
Version will be 1.6.2.
![image](https://github.com/user-attachments/assets/dac575bd-997d-4187-9a65-b8af892c31d6)
