### PR TITLE
feat: upgrade package MongoDB.Driver to version 3.3.0 only in netstandard2.1

### DIFF
--- a/MongoDbGenericRepository/DataAccess/Base/DataAccessBase.cs
+++ b/MongoDbGenericRepository/DataAccess/Base/DataAccessBase.cs
@@ -1,7 +1,6 @@
 ﻿using MongoDB.Driver;
 using MongoDB.Driver.Linq;
 using MongoDbGenericRepository.Models;
-using System;
 using System.Linq.Expressions;
 
 namespace MongoDbGenericRepository.DataAccess.Base
@@ -35,12 +34,22 @@ namespace MongoDbGenericRepository.DataAccess.Base
         /// <param name="filter">The filter definition.</param>
         /// <param name="partitionKey">The collection partition key.</param>
         /// <returns></returns>
+#if NETSTANDARD2_0 || NET472
         public virtual IMongoQueryable<TDocument> GetQuery<TDocument, TKey>(Expression<Func<TDocument, bool>> filter, string partitionKey = null)
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>
         {
             return GetCollection<TDocument, TKey>(partitionKey).AsQueryable().Where(filter);
         }
+#endif
+#if NETSTANDARD2_1_OR_GREATER
+        public virtual IQueryable<TDocument> GetQuery<TDocument, TKey>(Expression<Func<TDocument, bool>> filter, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            return GetCollection<TDocument, TKey>(partitionKey).AsQueryable().Where(filter);
+        }
+#endif
 
         /// <summary>
         /// Gets a collections for a potentially partitioned document type.

--- a/MongoDbGenericRepository/DataAccess/Base/IDataAccessBase.cs
+++ b/MongoDbGenericRepository/DataAccess/Base/IDataAccessBase.cs
@@ -1,8 +1,7 @@
-using System;
-using System.Linq.Expressions;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
 using MongoDbGenericRepository.Models;
+using System.Linq.Expressions;
 
 namespace MongoDbGenericRepository.DataAccess.Base
 {
@@ -19,9 +18,15 @@ namespace MongoDbGenericRepository.DataAccess.Base
         /// <param name="filter">The filter definition.</param>
         /// <param name="partitionKey">The collection partition key.</param>
         /// <returns></returns>
+#if NETSTANDARD2_0 || NET472
         IMongoQueryable<TDocument> GetQuery<TDocument, TKey>(Expression<Func<TDocument, bool>> filter, string partitionKey = null)
             where TDocument : IDocument<TKey>
             where TKey : IEquatable<TKey>;
+#elif NETSTANDARD2_1_OR_GREATER
+        IQueryable<TDocument> GetQuery<TDocument, TKey>(Expression<Func<TDocument, bool>> filter, string partitionKey = null)
+            where TDocument : IDocument<TKey>
+            where TKey : IEquatable<TKey>;
+#endif
 
         /// <summary>
         /// Gets a collections for a potentially partitioned document type.

--- a/MongoDbGenericRepository/MongoDbContext.cs
+++ b/MongoDbGenericRepository/MongoDbContext.cs
@@ -97,7 +97,9 @@ namespace MongoDbGenericRepository
             // GuidRepresentation and GuidRepresentationMode will be removed in the next major release of the MongoDB Driver.
             // We can safely replace this with RepositorySerializationProvider.Instance.RegisterSerializer once we upgrade to the next major release.
 #pragma warning disable CS0618
+#if NETSTANDARD2_0 || NET472
             BsonDefaults.GuidRepresentationMode = GuidRepresentationMode.V3;
+#endif
             RepositorySerializationProvider.Instance.RegisterSerializer(new GuidSerializer(guidRepresentation));
 #pragma warning restore CS0618
         }

--- a/MongoDbGenericRepository/MongoDbGenericRepository.csproj
+++ b/MongoDbGenericRepository/MongoDbGenericRepository.csproj
@@ -25,7 +25,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="[2.30.0,3)" />
     <None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="MongoDB.Driver" Version="[2.30.0,3)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="MongoDB.Driver" Version="[3.*,)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There is only one breaking change in the GetQuery method because IMongoQueryable does not exist in version 3.0.0 [see more at](https://www.mongodb.com/en-us/docs/drivers/csharp/current/upgrade/v3).